### PR TITLE
Remove storage deps when running on env config

### DIFF
--- a/src/main/kotlin/com/github/jochettino/fisojo/FisheyeHandler.kt
+++ b/src/main/kotlin/com/github/jochettino/fisojo/FisheyeHandler.kt
@@ -54,7 +54,7 @@ class FisheyeHandler constructor(
     }
 
     private fun addFromDateToQueryString(queryString: String): String {
-        val fromDateValue = System.currentTimeMillis() - (MINUTES_TO_LOOK_TO_THE_PAST * 60 * 1000)
+        val fromDateValue = System.currentTimeMillis() - (config.secondsToLookIntoThePast * 1000)
         return "$queryString&fromDate=$fromDateValue"
     }
 
@@ -84,6 +84,5 @@ class FisheyeHandler constructor(
         // Api doc site
         // https://docs.atlassian.com/fisheye-crucible/latest/wadl/crucible.html?_ga=2.248528775.1036500565.1544699056-786505459.1542885403#d1e897
         private const val API_FILTER_URL = "/rest-service/reviews-v1/filter"
-        private const val MINUTES_TO_LOOK_TO_THE_PAST = 1
     }
 }

--- a/src/main/kotlin/com/github/jochettino/fisojo/Run.kt
+++ b/src/main/kotlin/com/github/jochettino/fisojo/Run.kt
@@ -45,7 +45,7 @@ fun main(args: Array<String>) {
 
     val fisheyeHandler = FisheyeHandler(configHandler, loggerProvider)
     val slackHandler =
-        SlackHandler(configHandler.getSlackConfig(), configHandler.getFisheyeConfig())
+        SlackHandler(configHandler.getSlackConfig(), configHandler.getFisheyeConfig(), loggerProvider)
 
     while(true) {
         val reviewsData: List<ReviewData>

--- a/src/main/kotlin/com/github/jochettino/fisojo/SlackHandler.kt
+++ b/src/main/kotlin/com/github/jochettino/fisojo/SlackHandler.kt
@@ -3,6 +3,7 @@ package com.github.jochettino.fisojo
 import com.github.jochettino.fisojo.config.FisheyeConfig
 import com.github.jochettino.fisojo.config.SlackConfig
 import com.github.jochettino.fisojo.dto.ReviewData
+import com.github.jochettino.fisojo.logger.LoggerProvider
 import org.apache.http.client.methods.HttpPost
 import org.apache.http.entity.StringEntity
 import org.apache.http.impl.client.HttpClients
@@ -14,9 +15,11 @@ import java.util.Locale
 
 class SlackHandler constructor(
     private val config: SlackConfig,
-    fisheyeConfig: FisheyeConfig
+    fisheyeConfig: FisheyeConfig,
+    loggerProvider: LoggerProvider
 ){
 
+    private val logger = loggerProvider.getLogger(FisheyeHandler::class.simpleName!!)
     var lastHttpCall = ""
     val fisheyeBaseUrl = fisheyeConfig.baseServerUrl
 
@@ -24,6 +27,7 @@ class SlackHandler constructor(
         val formData = review.joinToString(",", """{"attachments":[""", "]}") { it.toSlack() }
         val httpPostRequest = buildHttpPostRequest(formData)
         val httpClient = HttpClients.createDefault()
+        logger.debug("Sending message to Slack")
         val response = httpClient.execute(httpPostRequest)
         if (response.statusLine.statusCode != org.apache.http.HttpStatus.SC_OK) {
             throw Exception("HTTP POST with payload $formData returned ${response.statusLine.statusCode} status code")

--- a/src/main/kotlin/com/github/jochettino/fisojo/config/ConfigDefaults.kt
+++ b/src/main/kotlin/com/github/jochettino/fisojo/config/ConfigDefaults.kt
@@ -1,0 +1,6 @@
+package com.github.jochettino.fisojo.config
+
+object ConfigDefaults {
+    const val POLLING_FREQUENCY = 60L
+    const val SECONDS_TO_LOOK_INTO_THE_PAST = 60L
+}

--- a/src/main/kotlin/com/github/jochettino/fisojo/config/ConfigHandler.kt
+++ b/src/main/kotlin/com/github/jochettino/fisojo/config/ConfigHandler.kt
@@ -16,7 +16,8 @@ data class FisheyeConfig (
     val baseServerUrl: String,
     // last review now in fisheye
     val lastCrNumber: Int,
-    val pollingFrequency: Long
+    val pollingFrequency: Long,
+    val secondsToLookIntoThePast: Long
 )
 
 data class SlackConfig (val webhookUrl: String)

--- a/src/main/kotlin/com/github/jochettino/fisojo/config/EnvironmentConfigHandlerImpl.kt
+++ b/src/main/kotlin/com/github/jochettino/fisojo/config/EnvironmentConfigHandlerImpl.kt
@@ -1,23 +1,16 @@
 package com.github.jochettino.fisojo.config
 
-import java.io.FileInputStream
-import java.io.FileOutputStream
-import java.util.Properties
-
 class EnvironmentConfigHandlerImpl: ConfigHandler {
 
     private lateinit var fisheyeConfig: FisheyeConfig
 
     private lateinit var slackConfig: SlackConfig
 
-    private lateinit var props: Properties
-
     init {
         buildConfigObjects()
     }
 
     private fun buildConfigObjects() {
-        props = loadLastCrNumberFile()
         fisheyeConfig = buildFisheyeConfig()
         slackConfig = buildSlackConfig()
     }
@@ -27,8 +20,10 @@ class EnvironmentConfigHandlerImpl: ConfigHandler {
             feauth = System.getenv(FISHEYE_FEAUTH) ?: "",
             projectId = System.getenv(FISHEYE_PROJECT_ID) ?: "",
             baseServerUrl = System.getenv(FISHEYE_BASE_SERVER_URL) ?: "",
-            lastCrNumber = props.getProperty(FISHEYE_LAST_CR_NUMBER).toInt(), // TODO: store last cr number in some storage
-            pollingFrequency = System.getenv(FISHEYE_POLLING_FREQUENCY).toLong()
+            lastCrNumber = 0,
+            pollingFrequency = System.getenv(FISHEYE_POLLING_FREQUENCY)?.toLong() ?: ConfigDefaults.POLLING_FREQUENCY,
+            secondsToLookIntoThePast = System.getenv(FISHEYE_SECONDS_TO_LOOK_INTO_THE_PAST)?.toLong()
+                    ?: ConfigDefaults.SECONDS_TO_LOOK_INTO_THE_PAST
         )
 
     private fun buildSlackConfig() =
@@ -39,29 +34,17 @@ class EnvironmentConfigHandlerImpl: ConfigHandler {
     override fun getSlackConfig() = slackConfig
 
     override fun updateLastCrNumber(lastCrNumber: Int) {
-        /**
-         * TODO: store last cr number in some storage
+        /*
+          No op, as no persistence is expected when running using ENV config.
          */
-        props.setProperty(FISHEYE_LAST_CR_NUMBER, lastCrNumber.toString())
-        props.store(FileOutputStream(LAST_CR_NUMBER_FILENAME), null)
-    }
-
-    private fun loadLastCrNumberFile(): Properties {
-        FileInputStream(LAST_CR_NUMBER_FILENAME).use { input ->
-            return Properties().apply {
-                load(input)
-            }
-        }
     }
 
     companion object {
-        private const val LAST_CR_NUMBER_FILENAME = "last-cr-number.txt"
-
         private const val FISHEYE_FEAUTH = "FISHEYE_FEAUTH"
         private const val FISHEYE_PROJECT_ID = "FISHEYE_PROJECT_ID"
         private const val FISHEYE_BASE_SERVER_URL = "FISHEYE_BASE_SERVER_URL"
-        private const val FISHEYE_LAST_CR_NUMBER = "FISHEYE_LAST_CR_NUMBER"
         private const val FISHEYE_POLLING_FREQUENCY = "FISHEYE_POLLING_FREQUENCY"
+        private const val FISHEYE_SECONDS_TO_LOOK_INTO_THE_PAST = "FISHEYE_SECONDS_TO_LOOK_INTO_THE_PAST"
 
         private const val SLACK_WEBHOOK_URL = "SLACK_WEBHOOK"
     }

--- a/src/main/kotlin/com/github/jochettino/fisojo/config/FileConfigHandlerImpl.kt
+++ b/src/main/kotlin/com/github/jochettino/fisojo/config/FileConfigHandlerImpl.kt
@@ -30,11 +30,11 @@ class FileConfigHandlerImpl constructor(
             projectId = props.getProperty(FISHEYE_PROJECT_ID),
             baseServerUrl = props.getProperty(FISHEYE_BASE_SERVER_URL),
             lastCrNumber = props.getProperty(FISHEYE_LAST_CR_NUMBER).toInt(),
-            pollingFrequency = props.getProperty(
-                FISHEYE_POLLING_FREQUENCY,
-                FISHEYE_FEAUTH_DEFAULT_VALLUE
-            ).toLong()
-        )
+            pollingFrequency = props.getProperty(FISHEYE_POLLING_FREQUENCY)?.toLong()
+                    ?: ConfigDefaults.POLLING_FREQUENCY,
+            secondsToLookIntoThePast = props.getProperty(FISHEYE_SECONDS_TO_LOOK_INTO_THE_PAST)?.toLong()
+                    ?: ConfigDefaults.SECONDS_TO_LOOK_INTO_THE_PAST
+    )
 
     private fun buildSlackConfig(props: Properties) =
         SlackConfig(webhookUrl = props.getProperty(SLACK_WEBHOOK_URL))
@@ -62,9 +62,8 @@ class FileConfigHandlerImpl constructor(
         private const val FISHEYE_BASE_SERVER_URL = "fisheye.baseServerUrl"
         private const val FISHEYE_LAST_CR_NUMBER = "fisheye.lastCrNumber"
         private const val FISHEYE_POLLING_FREQUENCY = "fisheye.polling.frequency"
+        private const val FISHEYE_SECONDS_TO_LOOK_INTO_THE_PAST = "fisheye.secondsToLookIntoThePast"
 
         private const val SLACK_WEBHOOK_URL = "slack.webhookUrl"
-
-        private const val FISHEYE_FEAUTH_DEFAULT_VALLUE = "30"
     }
 }


### PR DESCRIPTION
Make it k8s friendly, requiring no storage to run when using environment variable based config.

Currently the last revision is stored in memory within FisheyeHandler so this would make the external storage not needed in most cases.

"secondsToLookIntoThePast" now is configurable. Ideally, if pollingFrequency == secondsToLookIntoThePast then no duplicate messages should be sent (of course there's some edge cases, but better have some duplicated messages than missing them) 