### PR TITLE
Adding a simple docker file that builds the fat jar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM maven:3.6.3-jdk-8-slim
+COPY . /
+RUN mvn package -DskipTest
+ENTRYPOINT ["java", "-jar", "target/fisojo-1.3-SNAPSHOT-jar-with-dependencies.jar", "--debug"]


### PR DESCRIPTION
This creates a simple dockerfile that builds the jar and expects all the params required by fisojo to be en env variables

Run example

```
docker run --env SLACK_WEBHOOK_URL=<URL> --env FISHEYE_FEAUTH=<feauth> --env FISHEYE_BASE_SERVER_URL=<febase> --env FISHEYE_PROJECT_ID=<project> --env FISHEYE_POLLING_FREQUENCY=<freq> fisojo:latest